### PR TITLE
4 update deid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
     -   id: isort
         name: isort (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Contributions are welcome, and they are greatly appreciated! Every little bit
-helps, and credit will always be given. Our main communication channel is 
+helps, and credit will always be given. Our main communication channel is
 [Github Issues](https://github.com/mammoai/cobra-db/issues). The
 [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
 syntax is used for editing and formating.
@@ -85,10 +85,10 @@ Ready to contribute? Here's how to set up `cobra_db` for local development.
     pre-commit run --all-files
     ```
 
-7. Commit your changes following the 
-   [Angular Commit Message Format](https://gist.github.com/brianclements/841ea7bffdb01346392c) 
-   and open a pull request. Following the Angular message format, allows us to 
-   automaticallykeep track of the versions and the change log. A quick recap of the 
+7. Commit your changes following the
+   [Angular Commit Message Format](https://gist.github.com/brianclements/841ea7bffdb01346392c)
+   and open a pull request. Following the Angular message format, allows us to
+   automaticallykeep track of the versions and the change log. A quick recap of the
    format:
     ```
     <type>(<scope>): <subject>
@@ -99,19 +99,19 @@ Ready to contribute? Here's how to set up `cobra_db` for local development.
     ```
     Type must be one of the following:
     * **build**: Changes that affect the build system or external dependencies
-    * **ci**: Changes to our CI configuration files and scripts (github actions 
+    * **ci**: Changes to our CI configuration files and scripts (github actions
       workflows)
     * **docs**: Documentation only changes
     * **feat**: A new feature
     * **fix**: A bug fix
     * **perf**: A code change that improves performance
     * **refactor**: A code change that neither fixes a bug nor adds a feature
-    * **style**: Changes that do not affect the meaning of the code (white-space, 
+    * **style**: Changes that do not affect the meaning of the code (white-space,
       formatting, missing semi-colons, etc)
     * **test**: Adding missing tests or correcting existing tests
 
 ### Scope
-The scope should be the name of the npm package affected (as perceived by the person 
+The scope should be the name of the npm package affected (as perceived by the person
 reading the changelog generated from commit messages).
 
 

--- a/src/cobra_db/deid.py
+++ b/src/cobra_db/deid.py
@@ -2,7 +2,7 @@ import logging
 import os
 from copy import deepcopy
 from datetime import datetime
-from typing import Union, List
+from typing import List, Union
 
 import pydicom
 from deid.config import DeidRecipe

--- a/src/cobra_db/deid.py
+++ b/src/cobra_db/deid.py
@@ -2,6 +2,7 @@ import logging
 import os
 from copy import deepcopy
 from datetime import datetime
+from typing import Union, List
 
 import pydicom
 from deid.config import DeidRecipe
@@ -11,7 +12,8 @@ from deid.logger import bot
 from cobra_db.encrypt import Hasher
 from cobra_db.utils import parse_AS_as_int
 
-default_recipe_path = os.path.join(os.path.dirname(__file__), "deid_recipe.txt")
+base_recipe_path = os.path.join(os.path.dirname(__file__), "deid_recipe.txt")
+mr_recipe_path = os.path.join(os.path.dirname(__file__), "deid_recipe_mr.txt")
 
 deid_logging_levels = dict(
     ABORT=-5,
@@ -33,7 +35,7 @@ class Deider:
     def __init__(
         self,
         hasher_secret_salt: str,
-        recipe_path: str = None,
+        recipe_path: Union[str, List] = None,
         logging_level: str = "ERROR",
     ):
         """Deidentify datasets according to vaib recipe
@@ -42,10 +44,14 @@ class Deider:
         :param hasher_secret_salt: salt for hashing
         """
         bot.level = deid_logging_levels[logging_level]
-        assert os.path.exists(recipe_path), f"Invalid recipe_path: {recipe_path}"
+        if type(recipe_path) == list:
+            for r in recipe_path:
+                assert os.path.exists(r), f"Invalid recipe_path: {r}"
+        else:
+            assert os.path.exists(recipe_path), f"Invalid recipe_path: {recipe_path}"
         if recipe_path is None:
-            logging.warning(f"DeidDataset using default recipe {default_recipe_path}")
-            recipe_path = default_recipe_path
+            logging.warning(f"DeidDataset using default recipe {base_recipe_path}")
+            recipe_path = base_recipe_path
         self.recipe = DeidRecipe(recipe_path)
         self.hasher = Hasher(hasher_secret_salt)
 

--- a/src/cobra_db/deid.py
+++ b/src/cobra_db/deid.py
@@ -44,14 +44,14 @@ class Deider:
         :param hasher_secret_salt: salt for hashing
         """
         bot.level = deid_logging_levels[logging_level]
+        if recipe_path is None:
+            logging.warning(f"DeidDataset using default recipe {base_recipe_path}")
+            recipe_path = base_recipe_path
         if type(recipe_path) == list:
             for r in recipe_path:
                 assert os.path.exists(r), f"Invalid recipe_path: {r}"
         else:
             assert os.path.exists(recipe_path), f"Invalid recipe_path: {recipe_path}"
-        if recipe_path is None:
-            logging.warning(f"DeidDataset using default recipe {base_recipe_path}")
-            recipe_path = base_recipe_path
         self.recipe = DeidRecipe(recipe_path)
         self.hasher = Hasher(hasher_secret_salt)
 

--- a/src/cobra_db/deid_recipe.txt
+++ b/src/cobra_db/deid_recipe.txt
@@ -8,7 +8,7 @@
 #     stored. Weight is rounded to intervals of 5 kg. Length is rounded to intervals of
 #     5 cm. Age is rounded to intervals of 5 years.
 # •	Acquisition times are preserved.
-# •	Study description is preserved.
+# •	Study and series descriptions are preserved.
 # •	Retain Institution Identity Option is followed.
 # •	Retain Device Identity Option is followed.
 # •	Retain Longitudinal Temporal Information with Full Dates Option is followed.
@@ -19,7 +19,7 @@ FORMAT dicom
 %header
 
 ADD PatientIdentityRemoved Yes
-ADD DeidentificationMethod vaib_deid_v1.0.0
+ADD DeidentificationMethod vaib_deid_v1.0.1
 
 # Replacements with custom functions. Those can be found in cobra_db.deid
 
@@ -344,6 +344,7 @@ KEEP SelectorDAValue
 KEEP SelectorDTValue
 KEEP SelectorTMValue
 KEEP SeriesDate
+KEEP SeriesDescription
 KEEP SeriesInstanceUID
 KEEP SeriesTime
 KEEP SmokingStatus
@@ -596,7 +597,6 @@ REMOVE ScheduledPerformingPhysicianIdentificationSequence
 REMOVE ScheduledPerformingPhysicianName
 REMOVE ScheduledProcedureStepDescription
 REMOVE ScheduledProcedureStepID
-REMOVE SeriesDescription
 REMOVE ServiceEpisodeDescription
 REMOVE ServiceEpisodeID
 REMOVE SetupTechniqueDescription

--- a/src/cobra_db/deid_recipe_mr.txt
+++ b/src/cobra_db/deid_recipe_mr.txt
@@ -1,4 +1,10 @@
-# Addition to the VAI-B pseudonymization recipe to preserve dicom tags relevant to MRI studies.
+# This recipe can **only** act as an addition to the  VAI-B pseudonymization recipe (defined in deid_recipe.txt).
+#
+# It can be used on top of the VAI-B recipe (base) by setting the respecitve variable (mr) in the configuration file:
+# deid_default_recipes:
+#   base: true
+#   mr: true
+
 FORMAT dicom
 
 %header

--- a/src/cobra_db/deid_recipe_mr.txt
+++ b/src/cobra_db/deid_recipe_mr.txt
@@ -1,4 +1,4 @@
-# Addition to the VAI-B pseudonymization recipe to preserve dicom tags relevant to MRI studies. 
+# Addition to the VAI-B pseudonymization recipe to preserve dicom tags relevant to MRI studies.
 FORMAT dicom
 
 %header
@@ -92,4 +92,4 @@ KEEP TransferSyntaxUID
 KEEP TriggerWindow
 KEEP VariableFlipAngleFlag
 KEEP WindowCenter
-KEEP WindowWidth 
+KEEP WindowWidth

--- a/src/cobra_db/deid_recipe_mr.txt
+++ b/src/cobra_db/deid_recipe_mr.txt
@@ -1,0 +1,95 @@
+# Addition to the VAI-B pseudonymization recipe to preserve dicom tags relevant to MRI studies. 
+FORMAT dicom
+
+%header
+
+ADD PatientIdentityRemoved Yes
+ADD DeidentificationMethod mr_deid_v1.0.0
+
+# Tags removed by deid_recipe.txt and brought back for MR
+KEEP ProtocolName
+KEEP ReferencedImageSequence
+KEEP ReferencedPerformedProcedureStepSequence
+KEEP SeriesDescription
+
+# Addional new tags
+KEEP AcquisitionMatrix
+KEEP AcquisitionNumber
+KEEP AngioFlag
+KEEP BitsAllocated
+KEEP BitsStored
+KEEP CardiacNumberOfImages
+KEEP CodeMeaning
+KEEP CodeValue
+KEEP CodingSchemeDesignator
+KEEP Columns
+KEEP DeidentificationMethod
+KEEP DeidentificationMethodCodeSequence
+KEEP DiffusionBValue
+KEEP EchoNumbers
+KEEP EchoTime
+KEEP EchoTrainLength
+KEEP EffectiveEchoTime
+KEEP FileMetaInformationGroupLength
+KEEP FileMetaInformationVersion
+KEEP FlipAngle
+KEEP HighBit
+KEEP ImageOrientationPatient
+KEEP ImagePositionPatient
+KEEP ImageType
+KEEP ImagedNucleus
+KEEP ImagesInAcquisition
+KEEP ImagingFrequency
+KEEP ImplementationClassUID
+KEEP ImplementationVersionName
+KEEP InPlanePhaseEncodingDirection
+KEEP InStackPositionNumber
+KEEP InstanceNumber
+KEEP InversionTime
+KEEP LargestImagePixelValue
+KEEP Laterality
+KEEP MRAcquisitionType
+KEEP MRDiffusionSequence
+KEEP MREchoSequence
+KEEP MRFOVGeometrySequence
+KEEP MagneticFieldStrength
+KEEP Manufacturer
+KEEP ManufacturerModelName
+KEEP MediaStorageSOPClassUID
+KEEP Modality
+KEEP NumberOfAverages
+KEEP NumberOfTemporalPositions
+KEEP PatientPosition
+KEEP PercentPhaseFieldOfView
+KEEP PercentSampling
+KEEP PhotometricInterpretation
+KEEP PixelBandwidth
+KEEP PixelRepresentation
+KEEP PixelSpacing
+KEEP PlanarConfiguration
+KEEP PositionReferenceIndicator
+KEEP ReceiveCoilName
+KEEP ReconstructionDiameter
+KEEP ReferencedSOPClassUID
+KEEP RepetitionTime
+KEEP Rows
+KEEP SAR
+KEEP SOPClassUID
+KEEP SamplesPerPixel
+KEEP ScanOptions
+KEEP ScanningSequence
+KEEP SequenceVariant
+KEEP SeriesNumber
+KEEP SliceLocation
+KEEP SliceThickness
+KEEP SmallestImagePixelValue
+KEEP SoftwareVersions
+KEEP SpacingBetweenSlices
+KEEP SpecificCharacterSet
+KEEP StackID
+KEEP TemporalPositionIdentifier
+KEEP TransferSyntaxUID
+KEEP TriggerWindow
+KEEP VariableFlipAngleFlag
+KEEP WindowCenter
+KEEP WindowWidth 

--- a/src/cobra_db/filesystem.py
+++ b/src/cobra_db/filesystem.py
@@ -63,10 +63,5 @@ def get_series_path(ds: Dataset):
 
 def get_instance_path(ds: Dataset):
     """Get unique path for instance"""
-    instance_number = opt(ds, "InstanceNumber", None)
-
-    if instance_number:
-        key = instance_number
-    else:
-        key = ds.SOPInstanceUID
+    key = ds.SOPInstanceUID
     return os.path.join(get_series_path(ds), f"{key}.dcm")

--- a/tests/script_config/deid.yaml
+++ b/tests/script_config/deid.yaml
@@ -37,8 +37,14 @@ batch_size: 10
 # number of concurrent processes
 n_proc: 1
 
-# deid recipe path. How to deidentify the images. Set to null if default is to be used
-deid_recipe_path: null
+# This will use the default recipies in the specified order.
+deid_default_recipes:
+  base: true
+  mr: true
+# user deid recipe path(s). How to deidentify the images. Set to null if default is to be used
+# Latest in the list overrides the earlier
+# https://deid.readthedocs.io/en/latest/source/deid.config.html#deid.config.DeidRecipe
+user_recipe_path: []
 
 # logging config
 logging_dir: null

--- a/tests/script_config/deid.yaml
+++ b/tests/script_config/deid.yaml
@@ -37,7 +37,8 @@ batch_size: 10
 # number of concurrent processes
 n_proc: 1
 
-# This will use the default recipies in the specified order.
+# This will use the default recipies in the specified order
+# When the default recipes are used the base recipe should be always set to true, and it is optional to enable the mr recipe or not
 deid_default_recipes:
   base: true
   mr: true

--- a/tests/script_config/deid_multiproc.yaml
+++ b/tests/script_config/deid_multiproc.yaml
@@ -37,8 +37,14 @@ batch_size: 10
 # number of concurrent processes
 n_proc: 2
 
-# deid recipe path. How to deidentify the images. Set to null if default is to be used
-deid_recipe_path: null
+# This will use the default recipies in the specified order.
+deid_default_recipes:
+  base: true
+  mr: true
+# user deid recipe path(s). How to deidentify the images. Set to null if default is to be used
+# Latest in the list overrides the earlier
+# https://deid.readthedocs.io/en/latest/source/deid.config.html#deid.config.DeidRecipe
+user_recipe_path: []
 
 # logging config
 logging_dir: null

--- a/tests/script_config/deid_multiproc.yaml
+++ b/tests/script_config/deid_multiproc.yaml
@@ -37,7 +37,8 @@ batch_size: 10
 # number of concurrent processes
 n_proc: 2
 
-# This will use the default recipies in the specified order.
+# This will use the default recipies in the specified order
+# When the default recipes are used the base recipe should be always set to true, and it is optional to enable the mr recipe or not
 deid_default_recipes:
   base: true
   mr: true

--- a/tests/script_config/recipe_1.txt
+++ b/tests/script_config/recipe_1.txt
@@ -1,0 +1,1 @@
+KEEP SeriesDescription

--- a/tests/test_deid.py
+++ b/tests/test_deid.py
@@ -1,7 +1,7 @@
 import pydicom
 import pytest
 
-from cobra_db.deid import Deider, default_recipe_path
+from cobra_db.deid import Deider, base_recipe_path
 
 
 @pytest.fixture
@@ -66,6 +66,6 @@ def expected_ds():
 
 def test_deid_dataset(real_ds: pydicom.Dataset, expected_ds: pydicom.Dataset):
 
-    deider = Deider("AVerySecretSalt", default_recipe_path)
+    deider = Deider("AVerySecretSalt", base_recipe_path)
     pseudon_ds = deider.pseudonymize(real_ds)
     assert pseudon_ds.to_json() == expected_ds.to_json()

--- a/tests/test_deid.py
+++ b/tests/test_deid.py
@@ -69,3 +69,9 @@ def test_deid_dataset(real_ds: pydicom.Dataset, expected_ds: pydicom.Dataset):
     deider = Deider("AVerySecretSalt", base_recipe_path)
     pseudon_ds = deider.pseudonymize(real_ds)
     assert pseudon_ds.to_json() == expected_ds.to_json()
+
+
+def test_empty_recipe(real_ds: pydicom.Dataset, expected_ds: pydicom.Dataset):
+    deider = Deider("AVerySecretSalt")
+    pseudon_ds = deider.pseudonymize(real_ds)
+    assert pseudon_ds.to_json() == expected_ds.to_json()

--- a/tests/test_deid.py
+++ b/tests/test_deid.py
@@ -53,7 +53,7 @@ def expected_ds():
             "00100040": {"Value": ["F"], "vr": "CS"},
             "00101010": {"Value": ["030Y"], "vr": "AS"},
             "00120062": {"Value": ["Yes"], "vr": "CS"},
-            "00120063": {"Value": ["vaib_deid_v1.0.0"], "vr": "LO"},
+            "00120063": {"Value": ["vaib_deid_v1.0.1"], "vr": "LO"},
             "00200010": {
                 "Value": [
                     "fde000d590d076679bc13cb5ef1621ce8437f3e0512ea96d0404235f06f971d5"

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pydicom import read_file
 
-from cobra_db.deid import Deider, default_recipe_path
+from cobra_db.deid import Deider, base_recipe_path
 from cobra_db.filesystem import get_instance_path
 
 DICOM_PATH = "dicom_data/6774825273/09-11-2013-NA-XR CHEST AP PORTABLE for Scott Kaufman\
@@ -19,7 +19,7 @@ def real_ds():
 
 @pytest.fixture
 def deid_ds(real_ds):
-    deider = Deider("VerySecretSalt", default_recipe_path)
+    deider = Deider("VerySecretSalt", base_recipe_path)
     return deider.pseudonymize(real_ds)
 
 
@@ -38,6 +38,6 @@ def test_missing_PatientID():
     ds = read_file(data_path, stop_before_pixels=True)
     tag = ds.data_element("PatientID").tag
     del ds[tag]
-    deider = Deider("VerySecretSalt", default_recipe_path)
+    deider = Deider("VerySecretSalt", base_recipe_path)
     expected_path = get_instance_path(deider.pseudonymize(ds))
     assert expected_path == "UNK_PatientID/study_20040604/series_CR_054409_UNK/1001.dcm"

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -27,7 +27,8 @@ def test_get_instance_path(real_ds, deid_ds):
     with pytest.raises(AssertionError) as exc_info:
         get_instance_path(real_ds)
     assert exc_info.value.args[0] == "Length of patient hash is incorrect"
-    expected = "e18/2ce/29b495df648d52d1eb/study_20131109/series_CT_162723_UNK/1.dcm"
+    expected = "e18/2ce/29b495df648d52d1eb/study_20131109/series_CT_162723_UNK/\
+2.25.67591592645229809873011613207677746678.dcm"
     assert get_instance_path(deid_ds) == expected
 
 
@@ -40,4 +41,8 @@ def test_missing_PatientID():
     del ds[tag]
     deider = Deider("VerySecretSalt", base_recipe_path)
     expected_path = get_instance_path(deider.pseudonymize(ds))
-    assert expected_path == "UNK_PatientID/study_20040604/series_CR_054409_UNK/1001.dcm"
+    assert (
+        expected_path
+        == "UNK_PatientID/study_20040604/series_CR_054409_UNK/\
+2.25.303864294545422142998623082114092482038.dcm"
+    )

--- a/tests/test_pseudonymize_image_metadata.py
+++ b/tests/test_pseudonymize_image_metadata.py
@@ -79,8 +79,9 @@ def test_main(cfg):
     assert os.path.exists(
         os.path.join(
             dst_path,
-            "rel_path/to/my/dst_path/660/05c/ed21cd58352ee70252/study_20002605/series_\
-CT_125800_UNK/13.dcm",
+            "rel_path/to/my/dst_path/660/05c/ed21cd\
+58352ee70252/study_20002605/series_CT_125800_NEPHRO--4-0--B40f--M-0-4/2.25.9906061869367\
+4907730262422884187749878.dcm",
         )
     )
     # run for all images
@@ -105,7 +106,7 @@ O  4.0  B40f  M0.4-18678/1-007.dcm",
         os.path.join(
             dst_path,
             "rel_path/to/my/dst_path/660/05c/ed21cd58352ee70252/study_20002605/series_CT\
-_125800_UNK/7.dcm",
+_125800_NEPHRO--4-0--B40f--M-0-4/2.25.29709809808460026253134446579710279158.dcm",
         )
     )
 
@@ -141,8 +142,9 @@ def test_main_multiproc(cfg):
     assert os.path.exists(
         os.path.join(
             dst_path,
-            "rel_path/to/my/dst_path/660/05c/ed21cd58352ee70252/study_20002605/series_\
-CT_125800_UNK/13.dcm",
+            "rel_path/to/my/dst_path/660/05c/ed21cd\
+58352ee70252/study_20002605/series_CT_125800_NEPHRO--4-0--B40f--M-0-4/2.25.9906061869367\
+4907730262422884187749878.dcm",
         )
     )
     # run for all images
@@ -167,7 +169,7 @@ O  4.0  B40f  M0.4-18678/1-007.dcm",
         os.path.join(
             dst_path,
             "rel_path/to/my/dst_path/660/05c/ed21cd58352ee70252/study_20002605/series_CT\
-_125800_UNK/7.dcm",
+_125800_NEPHRO--4-0--B40f--M-0-4/2.25.29709809808460026253134446579710279158.dcm",
         )
     )
 


### PR DESCRIPTION
feat(pseudonymization): Add multiple de-identification recipes. 

Fixes #4. 
The de-identification process now includes two options for the user:
1. The default recipe, which consists of a) the base recipe as defined for VAI-B in deid_recipe.txt (mainly targeted for mammograms), and b) optionally an MR-related-tags-preserving recipe defined in deid_recipe_mr.txt. The latter can only act as an optional add-on to the base recipe. 
2. A completely user-defined deid recipe, described by one or more files, where order matters and the latest file overwrites the earlier in case there are intersecting dicom tags and actions.  